### PR TITLE
instarepo automatic PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.ngeor</groupId>
     <artifactId>java</artifactId>
-    <version>1.10.0</version>
+    <version>2.0.0</version>
   </parent>
   <artifactId>archetype-quickstart-jdk8</artifactId>
   <version>2.9.0-SNAPSHOT</version>


### PR DESCRIPTION
The following fixes have been applied:
- Updated parent pom

[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.github.ngeor:archetype-quickstart-jdk8 >-------------
[INFO] Building archetype-quickstart-jdk8 2.9.0-SNAPSHOT
[INFO] --------------------------[ maven-archetype ]---------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:update-parent (default-cli) @ archetype-quickstart-jdk8 ---
[INFO] artifact com.github.ngeor:java: checking for updates from central
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/github/ngeor/java/2.0.0/java-2.0.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/github/ngeor/java/2.0.0/java-2.0.0.pom (13 kB at 57 kB/s)
[INFO] Updating parent from 1.10.0 to 2.0.0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.119 s
[INFO] Finished at: 2021-10-10T09:50:07+02:00
[INFO] ------------------------------------------------------------------------
